### PR TITLE
Robustecido el cambio de tema

### DIFF
--- a/.config/alacritty/theme.py
+++ b/.config/alacritty/theme.py
@@ -4,22 +4,36 @@ import yaml
 
 
 def change_theme(alacritty_file, theme_file):
-    with open(alacritty_file) as f:
-        alacritty = yaml.load(f, Loader=yaml.FullLoader)
-    with open(theme_file) as f:
-        theme = yaml.load(f, Loader=yaml.FullLoader)
+    try:
+        with open(alacritty_file) as f:
+            alacritty = yaml.load(f, Loader=yaml.FullLoader)
+        with open(theme_file) as f:
+            theme = yaml.load(f, Loader=yaml.FullLoader)
+         
+        
+        if "colors" in theme:
+            alacritty["colors"] = theme["colors"]
+        else:
+            print("Theme \"{theme_file}\" has no color configuration.")
+            return False
 
-    alacritty["colors"] = theme["colors"]
-
-    with open(alacritty_file, "w") as f:
-        yaml.dump(alacritty, f)
+        with open(alacritty_file, "w") as f:
+            yaml.dump(alacritty, f)
+                  
+    except PermissionError as e:
+        print("Can't read/write {0.filename} : Not allowed".format(e))
+    except yaml.YAMLError as e:
+        print("YAML error at parsing file:\n at line {0.problem_mark.line}, column {0.problem_mark.column} : {0.problem} {0.context}".format(e))
+    else:
+        return True
+    return False
 
 
 def main():
     if len(argv) != 2:
         print("Usage:\npython {} theme.yaml".format(argv[0]))
         exit(0)
-
+    
     if not path.exists(argv[1]):
         print("Theme file {} does not exist".format(argv[1]))
         exit(0)
@@ -28,8 +42,10 @@ def main():
         path.expanduser("~"),
         ".config/alacritty/alacritty.yml"
     )
-    change_theme(alacritty_path, argv[1])
-    print("Theme successfully changed")
+    if change_theme(alacritty_path, argv[1]):
+        print("Theme successfully changed")
+    else:
+        print("Could not change theme.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
He modificado la función `change_theme` de la siguiente manera:
 - Añadido un bloque `try`/`except` para poder informar en caso de fallo.
 - Añadido un bloque `except` para errores de permiso, por ejemplo si se trata de cambiar el tema de un usuario al que no se le tiene acceso.
 - Añadido un bloque `except` para los errores del parser de YAML, sorprendentemente tenía valores para indicar la línea y la columna, pero en el traceback no te lo dice. De esta forma será más sencillo arreglar la configuración.
- Añadido un check en caso de que la configuración pasada no tenga sección de colores, informando en dicho caso.
-  Añadidas varias instrucciones de retorno para indicar fallo o éxito.

Como consecuencia de estos cambios, he añadido en la función `main` una instrucción de lógica para informar de que se ha o no se ha aplicado la configuración deseada.