### PR TITLE
Changed range function to enumerate

### DIFF
--- a/.config/qtile/config.py
+++ b/.config/qtile/config.py
@@ -157,14 +157,14 @@ keys = [Key(key[0], key[1], *key[2:]) for key in [
 
 groups = [Group(i) for i in ["NET", "DEV", "TERM", "FS", "MEDIA", "MISC"]]
 
-for i in range(len(groups)):
+for i, group in enumerate(groups):
     # Each workspace is identified by a number starting at 1
-    actual_key = i + 1
+    actual_key = str(i + 1)
     keys.extend([
         # Switch to workspace N (actual_key)
-        Key([mod], str(actual_key), lazy.group[groups[i].name].toscreen()),
+        Key([mod], actual_key, lazy.group[group.name].toscreen()),
         # Send window to workspace N (actual_key)
-        Key([mod, "shift"], str(actual_key), lazy.window.togroup(groups[i].name))
+        Key([mod, "shift"], actual_key, lazy.window.togroup(group.name))
     ])
 
 


### PR DESCRIPTION
This way you unpack the index and group of the list of groups (and DRY by doing the same thing two times).
`actual_key` is passed as string when declared and not at use.