### PR TITLE
Added NF icons to xmonad

### DIFF
--- a/.config/xmonad/xmonad.hs
+++ b/.config/xmonad/xmonad.hs
@@ -114,7 +114,8 @@ xmobarEscape = concatMap doubleLts
 
 myWorkspaces :: [String]
 myWorkspaces = clickable . (map xmobarEscape)
-    $ ["www", "dev", "term", "ref", "sys", "fs", "img", "vid", "misc"]
+--                                                                                         
+    $ ["\xf269 ", "\xe235 ", "\xe795 ", "\xf121 ", "\xe615 ", "\xf74a ", "\xf7e8 ", "\xf03d ", "\xf827 "]
   where
     clickable l = ["<action=xdotool key super+" ++ show (i) ++ "> " ++ ws ++ "</action>" | (i, ws) <- zip [1 .. 9] l]
 


### PR DESCRIPTION
Converted the workspaces from words to the same icons from [qtile](.config/qtile/settings/groups.py), using escape codes instead as ghc doesn't seem to like those unicode characters. The space after the escaped value is necessary as if it is not present only half of the icon will be displayed. Adding the space doesn't add any padding to it as the area which would be occupied by the space character is overdrawn by the icon.