### PR TITLE
Volume output format is now constant

### DIFF
--- a/.local/bin/volume
+++ b/.local/bin/volume
@@ -3,7 +3,7 @@
 vol=`pamixer --get-volume`
 
 if [[ `pamixer --get-mute` == "true" ]]; then
-    echo -n "ﱝ  $vol% "
+    echo -n "ﱝ $vol% "
 else
-    echo -n "$(percentage $vol   奔 墳  ) $vol%"
+    echo -n "$(percentage $vol   奔 墳  ) $vol% "
 fi


### PR DESCRIPTION
Volume script had different format depending on the muted state. It had more space in between the icon and percentage than the non-muted format. Now format matches the rest of the widgets as well.