### PR TITLE
Import correction

### DIFF
--- a/.config/qtile/settings/groups.py
+++ b/.config/qtile/settings/groups.py
@@ -5,7 +5,7 @@
 # Qtile workspaces
 
 from libqtile.config import Key, Group
-from libqtile.command import lazy
+from libqtile.lazy import lazy
 from .keys import mod, keys
 
 

--- a/.config/qtile/settings/keys.py
+++ b/.config/qtile/settings/keys.py
@@ -5,7 +5,7 @@
 # Qtile keybindings
 
 from libqtile.config import Key
-from libqtile.command import lazy
+from libqtile.lazy import lazy
 
 
 mod = "mod4"

--- a/.config/qtile/settings/mouse.py
+++ b/.config/qtile/settings/mouse.py
@@ -1,5 +1,5 @@
 from libqtile.config import Drag, Click
-from libqtile.command import lazy
+from libqtile.lazy import lazy
 from .keys import mod
 
 


### PR DESCRIPTION
PR Title: Fix ImportError for lazy in Qtile 0.26.0 Configuration
Description:

In the new version Qtile 0.26.0, released on 2024-05-21, the following errors have occurred in the repository configuration:

```
ImportError: cannot import name 'lazy' from 'libqtile.command' (/usr/lib/python3.12/site-packages/libqtile/command/__init__.py)

```
This PR introduces changes that resolve this error by updating the import statement for lazy:

```

from libqtile.lazy import lazy

```
Changes:
Updated import statement in the configuration files from from libqtile.command import lazy to from libqtile.lazy import lazy.

Justification:
The structure of the Qtile library has changed in the latest release, moving the lazy module from libqtile.command to libqtile.lazy. This change is necessary to ensure compatibility with Qtile 0.26.0 and to prevent the ImportError.
Testing:

    Verified the configuration loads correctly without ImportError.
    Tested basic functionality to ensure no other issues are introduced by this change.

Additional Notes:

    Users should be aware of this change if they are updating from a previous version of Qtile and adjust their configurations accordingly.