### PR TITLE
Fixed the lazy error in the last qtile update

### DIFF
--- a/.config/qtile/settings/groups.py
+++ b/.config/qtile/settings/groups.py
@@ -5,7 +5,7 @@
 # Qtile workspaces
 
 from libqtile.config import Key, Group
-from libqtile.command import lazy
+from libqtile.lazy import lazy
 from .keys import mod, keys
 
 

--- a/.config/qtile/settings/keys.py
+++ b/.config/qtile/settings/keys.py
@@ -5,7 +5,7 @@
 # Qtile keybindings
 
 from libqtile.config import Key
-from libqtile.command import lazy
+from libqtile.lazy import lazy
 
 
 mod = "mod4"

--- a/.config/qtile/settings/mouse.py
+++ b/.config/qtile/settings/mouse.py
@@ -1,5 +1,5 @@
 from libqtile.config import Drag, Click
-from libqtile.command import lazy
+from libqtile.lazy import lazy
 from .keys import mod
 
 


### PR DESCRIPTION
### Qtile stopped working after system update 

**The new qtile update requires changes in the lazy import**

from modules.groups import groups
  File "/home/jj/.config/qtile/modules/groups.py", line 2, in <module>
    from libqtile.command import **lazy**
ImportError: cannot import name 'lazy' from 'libqtile.command' (/usr/lib/python3.12/site-packages/libqtile/command/__init__.py)
2024-06-01 11:39:12,986 WARNING libqtile utils.py:send_notification():L297 dbus-next is not installed. Unable to send notifications.
2024-06-01 11:41:39,703 ERROR libqtile manager.py:spawn():L1280 couldn't find `mercury`